### PR TITLE
Fix license error while building

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,7 @@ dynamic = ["version"]
 description = "Convert audio files to Toniebox compatible format (.TAF) and interact with TeddyCloud."
 readme = "README.md"
 requires-python = ">=3.10"
-license = "GPL-3.0-or-later"
-license-files = ["LICENSE.md"]
+license = { file = "LICENSE.md" }
 keywords = [
     "toniebox",
     "tonie",


### PR DESCRIPTION
Fixes the error:
```
/usr/local/lib/python3.11/site-packages/setuptools/config/pyprojecttoml.py:104: _BetaConfiguration: Support for `[tool.setuptools]` in `pyproject.toml` is still *beta*.
  warnings.warn(msg, _BetaConfiguration)
configuration error: `project.license` must be valid exactly by one definition (2 matches found):

    - keys:
        'file': {type: string}
      required: ['file']
    - keys:
        'text': {type: string}
      required: ['text']

DESCRIPTION:
    `Project license <https://www.python.org/dev/peps/pep-0621/#license>`_.

GIVEN VALUE:
    "GPL-3.0-or-later"

OFFENDING RULE: 'oneOf'

DEFINITION:
    {
        "oneOf": [
            {
                "properties": {
                    "file": {
                        "type": "string",
                        "$$description": [
                            "Relative path to the file (UTF-8) which contains the license for the",
                            "project."
                        ]
                    }
                },
                "required": [
                    "file"
                ]
            },
            {
                "properties": {
                    "text": {
                        "type": "string",
                        "$$description": [
                            "The license of the project whose meaning is that of the",
                            "`License field from the core metadata",
                            "<https://packaging.python.org/specifications/core-metadata/#license>`_."
                        ]
                    }
                },
                "required": [
                    "text"
                ]
            }
        ]
    }
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "setup.py", line 10, in <module>
    setup()
  File "/usr/local/lib/python3.11/site-packages/setuptools/__init__.py", line 87, in setup
    return distutils.core.setup(**attrs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/setuptools/_distutils/core.py", line 151, in setup
    dist.parse_config_files()
  File "/usr/local/lib/python3.11/site-packages/setuptools/dist.py", line 868, in parse_config_files
    pyprojecttoml.apply_configuration(self, filename, ignore_option_errors)
  File "/usr/local/lib/python3.11/site-packages/setuptools/config/pyprojecttoml.py", line 58, in apply_configuration
    config = read_configuration(filepath, True, ignore_option_errors, dist)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/setuptools/config/pyprojecttoml.py", line 122, in read_configuration
    validate(subset, filepath)
  File "/usr/local/lib/python3.11/site-packages/setuptools/config/pyprojecttoml.py", line 47, in validate
    raise error from None
ValueError: invalid pyproject.toml config: `project.license`
*** Error code 1
```